### PR TITLE
[CMake] require C++ >= 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ include("${JRL_CMAKE_MODULES}/base.cmake")
 # Project definition
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)
 project(aig ${PROJECT_ARGS})
+check_minimal_cxx_standard(11 ENFORCE)
 
 # Dependencies
 add_project_dependency(pinocchio REQUIRED)


### PR DESCRIPTION
To fix build on 16.04, where:

```
In file included from /local/robotpkg/var/tmp/robotpkg/wip/aig/work/aig-1.0.0/src/leg_ig.cpp:7:0:
/local/robotpkg/var/tmp/robotpkg/wip/aig/work/aig-1.0.0/include/aig/leg_ig.hpp:29:58: error: non-static data member initializers only available with -std=c++11 or -std=gnu++11 [-Werror]
Eigen::Vector3d hip_from_waist = Eigen::Vector3d::Zero();
^
```


ref. http://robotpkg.openrobots.org/rbulk/robotpkg-wip/wip/aig/aig-1.0.0/Ubuntu-16.04-x86_64/build.html