### PR TITLE
fix example-robot-data depenency by a small change on the API

### DIFF
--- a/include/aig/biped_ig.hpp
+++ b/include/aig/biped_ig.hpp
@@ -35,8 +35,8 @@ struct BipedIGSettings {
   std::string right_knee_joint_name = "";
   std::string right_ankle_joint_name = "";
   std::string right_foot_frame_name = "";
-  std::string urdf_path = "";
-  std::string srdf_path = "";
+  std::string urdf = "";
+  std::string srdf = "";
 
   friend std::ostream &operator<<(std::ostream &out,
                                   const BipedIGSettings &obj) {
@@ -49,8 +49,8 @@ struct BipedIGSettings {
     out << "    right_knee_joint_name: " << obj.right_knee_joint_name << "\n";
     out << "    right_ankle_joint_name: " << obj.right_ankle_joint_name << "\n";
     out << "    right_foot_frame_name: " << obj.right_foot_frame_name << "\n";
-    out << "    urdf_path: " << obj.urdf_path << "\n";
-    out << "    srdf_path: " << obj.srdf_path << std::endl;
+    out << "    urdf: " << obj.urdf << "\n";
+    out << "    srdf: " << obj.srdf << std::endl;
     return out;
   }
 
@@ -65,8 +65,8 @@ struct BipedIGSettings {
     test &= lhs.right_knee_joint_name == rhs.right_knee_joint_name;
     test &= lhs.right_ankle_joint_name == rhs.right_ankle_joint_name;
     test &= lhs.right_foot_frame_name == rhs.right_foot_frame_name;
-    test &= lhs.urdf_path == rhs.urdf_path;
-    test &= lhs.srdf_path == rhs.srdf_path;
+    test &= lhs.urdf == rhs.urdf;
+    test &= lhs.srdf == rhs.srdf;
     return test;
   }
 };

--- a/include/aig/biped_ig.hpp
+++ b/include/aig/biped_ig.hpp
@@ -35,7 +35,15 @@ struct BipedIGSettings {
   std::string right_knee_joint_name = "";
   std::string right_ankle_joint_name = "";
   std::string right_foot_frame_name = "";
+  /**
+   * @brief This must contain either a valid path to the urdf file or the
+   * content of this file in a string.
+   */
   std::string urdf = "";
+  /**
+   * @brief This must contain either a valid path to the srdf file or the
+   * content of this file in a string.
+   */
   std::string srdf = "";
 
   friend std::ostream &operator<<(std::ostream &out,

--- a/include/aig/biped_ig.hpp
+++ b/include/aig/biped_ig.hpp
@@ -71,7 +71,8 @@ struct BipedIGSettings {
   }
 };
 
-BipedIGSettings makeSettingsFor(std::string robot_name);
+BipedIGSettings makeSettingsFor(const std::string &path_to_robots,
+                                const std::string &robot_name);
 
 /**
  * @brief @todo Describe BipedIG

--- a/src/biped_ig.cpp
+++ b/src/biped_ig.cpp
@@ -25,8 +25,8 @@ BipedIGSettings makeSettingsFor(const std::string &path_to_robots,
                  robot_name_lower.begin(),
                  [](unsigned char c) { return std::tolower(c); });
   if (robot_name_lower == "talos") {
-    robot_settings.urdf_path = path_to_robots + "/robots/talos_reduced.urdf";
-    robot_settings.srdf_path = path_to_robots + "/srdf/talos.srdf";
+    robot_settings.urdf = path_to_robots + "/robots/talos_reduced.urdf";
+    robot_settings.srdf = path_to_robots + "/srdf/talos.srdf";
 
     robot_settings.left_hip_joint_name = "leg_left_1_joint";
     robot_settings.right_hip_joint_name = "leg_right_1_joint";
@@ -65,24 +65,23 @@ void BipedIG::initialize(const BipedIGSettings &settings) {
   bool urdf_file_exists = false;
   bool srdf_file_exists = false;
   {
-    std::ifstream f(settings_.urdf_path.c_str());
+    std::ifstream f(settings_.urdf.c_str());
     urdf_file_exists = f.good();
   }
   {
-    std::ifstream f(settings_.srdf_path.c_str());
+    std::ifstream f(settings_.srdf.c_str());
     srdf_file_exists = f.good();
   }
 
   // Build the robot model.
   if (urdf_file_exists) {
-    pinocchio::urdf::buildModel(settings_.urdf_path,
+    pinocchio::urdf::buildModel(settings_.urdf,
                                 pinocchio::JointModelFreeFlyer(), model_);
-  } else if (settings_.urdf_path != "") {
+  } else if (settings_.urdf != "") {
     pinocchio::urdf::buildModelFromXML(
-        settings_.urdf_path, pinocchio::JointModelFreeFlyer(), model_);
+        settings_.urdf, pinocchio::JointModelFreeFlyer(), model_);
   } else {
-    throw std::runtime_error(
-        "BipedIG::BipedIG(): settings_.urdf_path is empty");
+    throw std::runtime_error("BipedIG::BipedIG(): settings_.urdf is empty");
   }
   // Build pinocchio cache.
   data_ = pinocchio::Data(model_);
@@ -95,15 +94,13 @@ void BipedIG::initialize(const BipedIGSettings &settings) {
 
   // Extract the CoM to Waist level arm.
   if (srdf_file_exists) {
-    pinocchio::srdf::loadReferenceConfigurations(model_, settings_.srdf_path,
-                                                 false);
-  } else if (settings_.srdf_path != "") {
+    pinocchio::srdf::loadReferenceConfigurations(model_, settings_.srdf, false);
+  } else if (settings_.srdf != "") {
     std::stringstream buffer;
-    buffer << settings_.srdf_path;
+    buffer << settings_.srdf;
     pinocchio::srdf::loadReferenceConfigurationsFromXML(model_, buffer, false);
   } else {
-    throw std::runtime_error(
-        "BipedIG::BipedIG(): settings_.srdf_path is empty");
+    throw std::runtime_error("BipedIG::BipedIG(): settings_.srdf is empty");
   }
   q0_ = model_.referenceConfigurations["half_sitting"];
   set_com_from_waist(q0_);

--- a/src/biped_ig.cpp
+++ b/src/biped_ig.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <cctype>
 
-#include "example-robot-data/path.hpp"
 #include "pinocchio/algorithm/center-of-mass.hpp"
 #include "pinocchio/algorithm/centroidal.hpp"
 #include "pinocchio/algorithm/rnea.hpp"
@@ -18,16 +17,14 @@
 
 namespace aig {
 
-BipedIGSettings makeSettingsFor(std::string robot_name) {
+BipedIGSettings makeSettingsFor(const std::string &path_to_robots,
+                                const std::string &robot_name) {
   BipedIGSettings robot_settings;
-
-  std::transform(robot_name.begin(), robot_name.end(), robot_name.begin(),
+  std::string robot_name_lower = robot_name;
+  std::transform(robot_name_lower.begin(), robot_name_lower.end(),
+                 robot_name_lower.begin(),
                  [](unsigned char c) { return std::tolower(c); });
-  if (robot_name == "talos") {
-    // const std::string path_to_robots =
-    // "/opt/pal/ferrum/share/talos_description";
-    const std::string path_to_robots =
-        EXAMPLE_ROBOT_DATA_MODEL_DIR "/talos_data";
+  if (robot_name_lower == "talos") {
     robot_settings.urdf_path = path_to_robots + "/robots/talos_reduced.urdf";
     robot_settings.srdf_path = path_to_robots + "/srdf/talos.srdf";
 

--- a/tests/aig/unittests/pyrene_settings.hpp
+++ b/tests/aig/unittests/pyrene_settings.hpp
@@ -20,9 +20,9 @@
 namespace aig {
 namespace unittests {
 const std::string path_to_robots = EXAMPLE_ROBOT_DATA_MODEL_DIR;
-const std::string urdf_path =
+const std::string urdf =
     path_to_robots + "/talos_data/robots/talos_reduced_corrected.urdf";
-const std::string srdf_path = path_to_robots + "/talos_data/srdf/talos.srdf";
+const std::string srdf = path_to_robots + "/talos_data/srdf/talos.srdf";
 
 const std::string left_hip_joint_name = "leg_left_1_joint";
 const std::string right_hip_joint_name = "leg_right_1_joint";
@@ -60,8 +60,8 @@ aig::BipedIGSettings bipeds = {
     right_knee_joint_name,  /* right_knee_joint_name */
     right_ankle_joint_name, /* right_ankle_joint_name */
     right_foot_frame_name,  /* right_foot_frame_name */
-    urdf_path,              /* urdf_path */
-    srdf_path               /* srdf_path */
+    urdf,                   /* urdf paths */
+    srdf                    /* srdf paths */
 };
 
 }  // namespace unittests

--- a/tests/test_arm_ig.cpp
+++ b/tests/test_arm_ig.cpp
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 
 BOOST_AUTO_TEST_CASE(test_leg_ig_constructor) {
   pinocchio::Model model;
-  pinocchio::urdf::buildModel(aig::unittests::urdf_path,
+  pinocchio::urdf::buildModel(aig::unittests::urdf,
                               pinocchio::JointModelFreeFlyer(), model);
   BOOST_CHECK_EQUAL(model.name, "talos");
 }

--- a/tests/test_biped_ig.cpp
+++ b/tests/test_biped_ig.cpp
@@ -2,6 +2,7 @@
 
 #include "aig/biped_ig.hpp"
 #include "aig/unittests/pyrene_settings.hpp"
+#include "example-robot-data/path.hpp"
 #include "pinocchio/algorithm/center-of-mass.hpp"
 #include "pinocchio/algorithm/frames.hpp"
 #include "pinocchio/algorithm/joint-configuration.hpp"
@@ -12,7 +13,9 @@
 BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 
 BOOST_AUTO_TEST_CASE(test_biped_ig_talos_settings) {
-  aig::BipedIGSettings talos_settings = aig::makeSettingsFor("talos");
+  const std::string path_to_robots = EXAMPLE_ROBOT_DATA_MODEL_DIR "/talos_data";
+  aig::BipedIGSettings talos_settings =
+      aig::makeSettingsFor(path_to_robots, "talos");
   aig::BipedIG biped_ig(talos_settings);
   BOOST_CHECK_EQUAL(biped_ig.get_settings(), talos_settings);
 }

--- a/tests/test_biped_ig.cpp
+++ b/tests/test_biped_ig.cpp
@@ -38,11 +38,11 @@ BOOST_AUTO_TEST_CASE(test_biped_ig_init_constructor_urdf_content) {
   aig::BipedIG biped_ig_1(settings);
 
   // read the urdf:
-  std::ifstream file(settings.urdf_path.c_str());
+  std::ifstream file(settings.urdf.c_str());
   std::stringstream buffer;
   buffer << file.rdbuf();
   // Save the urdf content into a string
-  settings.urdf_path = buffer.str();
+  settings.urdf = buffer.str();
   aig::BipedIG biped_ig_2(settings);
 
   // Check that both pinocchio model are equal.
@@ -54,11 +54,11 @@ BOOST_AUTO_TEST_CASE(test_biped_ig_init_constructor_srdf_content) {
   aig::BipedIG biped_ig_1(settings);
 
   // read the urdf:
-  std::ifstream file(settings.srdf_path.c_str());
+  std::ifstream file(settings.srdf.c_str());
   std::stringstream buffer;
   buffer << file.rdbuf();
   // Save the urdf content into a string
-  settings.srdf_path = buffer.str();
+  settings.srdf = buffer.str();
   aig::BipedIG biped_ig_2(settings);
 
   // Check that both pinocchio model are equal.
@@ -87,10 +87,10 @@ void generate_references(Eigen::Vector3d& com, pinocchio::SE3& base,
                          Eigen::VectorXd& q, const Mode& mode) {
   // Get the model and data
   pinocchio::Model model;
-  pinocchio::urdf::buildModel(aig::unittests::urdf_path,
+  pinocchio::urdf::buildModel(aig::unittests::urdf,
                               pinocchio::JointModelFreeFlyer(), model);
   pinocchio::Data data = pinocchio::Data(model);
-  pinocchio::srdf::loadReferenceConfigurations(model, aig::unittests::srdf_path,
+  pinocchio::srdf::loadReferenceConfigurations(model, aig::unittests::srdf,
                                                false);
 
   // Generate a robot configuration.

--- a/tests/test_dependencies_usage.cpp
+++ b/tests/test_dependencies_usage.cpp
@@ -11,7 +11,7 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 
 BOOST_AUTO_TEST_CASE(test_load_talos_model) {
   pinocchio::Model model;
-  pinocchio::urdf::buildModel(aig::unittests::urdf_path,
+  pinocchio::urdf::buildModel(aig::unittests::urdf,
                               pinocchio::JointModelFreeFlyer(), model);
   BOOST_CHECK_EQUAL(model.name, "talos");
 }
@@ -20,7 +20,7 @@ BOOST_AUTO_TEST_CASE(test_load_talos_model_from_xml) {
   pinocchio::Model model;
 
   // Read file as XML
-  std::ifstream file(aig::unittests::urdf_path.c_str());
+  std::ifstream file(aig::unittests::urdf.c_str());
   std::stringstream buffer;
   buffer << file.rdbuf();
   pinocchio::urdf::buildModelFromXML(buffer.str(),
@@ -30,10 +30,10 @@ BOOST_AUTO_TEST_CASE(test_load_talos_model_from_xml) {
 
 BOOST_AUTO_TEST_CASE(test_get_reference_config_from_xml) {
   pinocchio::Model model;
-  pinocchio::urdf::buildModel(aig::unittests::urdf_path,
+  pinocchio::urdf::buildModel(aig::unittests::urdf,
                               pinocchio::JointModelFreeFlyer(), model);
   // creating the srdf file stream
-  std::ifstream srdf_file(aig::unittests::srdf_path.c_str());
+  std::ifstream srdf_file(aig::unittests::srdf.c_str());
 
   // Load the srdf
   std::stringstream buffer;
@@ -45,9 +45,9 @@ BOOST_AUTO_TEST_CASE(test_get_reference_config_from_xml) {
 
 BOOST_AUTO_TEST_CASE(test_get_reference_config) {
   pinocchio::Model model;
-  pinocchio::urdf::buildModel(aig::unittests::urdf_path,
+  pinocchio::urdf::buildModel(aig::unittests::urdf,
                               pinocchio::JointModelFreeFlyer(), model);
-  pinocchio::srdf::loadReferenceConfigurations(model, aig::unittests::srdf_path,
+  pinocchio::srdf::loadReferenceConfigurations(model, aig::unittests::srdf,
                                                false);
   Eigen::VectorXd q = model.referenceConfigurations["half_sitting"];
   BOOST_CHECK_EQUAL(q.size(), model.nq);
@@ -55,9 +55,9 @@ BOOST_AUTO_TEST_CASE(test_get_reference_config) {
 
 BOOST_AUTO_TEST_CASE(test_compute_joint_placement) {
   pinocchio::Model model;
-  pinocchio::urdf::buildModel(aig::unittests::urdf_path,
+  pinocchio::urdf::buildModel(aig::unittests::urdf,
                               pinocchio::JointModelFreeFlyer(), model);
-  pinocchio::srdf::loadReferenceConfigurations(model, aig::unittests::srdf_path,
+  pinocchio::srdf::loadReferenceConfigurations(model, aig::unittests::srdf,
                                                false);
   Eigen::VectorXd q = model.referenceConfigurations["half_sitting"];
 
@@ -68,9 +68,9 @@ BOOST_AUTO_TEST_CASE(test_compute_joint_placement) {
 
 BOOST_AUTO_TEST_CASE(test_compute_com) {
   pinocchio::Model model;
-  pinocchio::urdf::buildModel(aig::unittests::urdf_path,
+  pinocchio::urdf::buildModel(aig::unittests::urdf,
                               pinocchio::JointModelFreeFlyer(), model);
-  pinocchio::srdf::loadReferenceConfigurations(model, aig::unittests::srdf_path,
+  pinocchio::srdf::loadReferenceConfigurations(model, aig::unittests::srdf,
                                                false);
   Eigen::VectorXd q = model.referenceConfigurations["half_sitting"];
   pinocchio::Data data(model);

--- a/tests/test_leg_ig.cpp
+++ b/tests/test_leg_ig.cpp
@@ -38,10 +38,10 @@ void generate_references(pinocchio::SE3& base, pinocchio::SE3& lf,
                          aig::LegJoints& rl_q, const Mode& mode) {
   // Get the model and data
   pinocchio::Model model;
-  pinocchio::urdf::buildModel(aig::unittests::urdf_path,
+  pinocchio::urdf::buildModel(aig::unittests::urdf,
                               pinocchio::JointModelFreeFlyer(), model);
   pinocchio::Data data = pinocchio::Data(model);
-  pinocchio::srdf::loadReferenceConfigurations(model, aig::unittests::srdf_path,
+  pinocchio::srdf::loadReferenceConfigurations(model, aig::unittests::srdf,
                                                false);
 
   // Generate a robot configuration.


### PR DESCRIPTION
Hi,

This PR is in response to this issue https://github.com/Gepetto/aig/issues/19

I did an update in the API to prevent a dependency to the example-robot-data package in the main API.
Only the unit-tests depends on it.

In exchange to that the user need to provide the path to the robot_description package.
I believe it's a small cost to pay, but let me know if you think it's not the best way.
